### PR TITLE
Added option argument-type

### DIFF
--- a/src/ServerScriptService/MainModule/Server/Core/Processor.lua
+++ b/src/ServerScriptService/MainModule/Server/Core/Processor.lua
@@ -201,6 +201,17 @@ return function()
 				end
 				
 				ParsedArgs[RealArg.Name] = EnumItem or Default or EnumType:GetEnumItems()[1]
+			elseif RealArg.Type == "option" or RealArg.Type == "selection" then
+				local Options = RealArg.TypeModifier:gsub(" ", ""):split(",")
+				local Choice
+
+				for j, Option in ipairs(Options) do
+					if lower(InputArg) == lower(Option):sub(1, #InputArg) or (tonumber(InputArg) and tonumber(InputArg) == j) then
+						Choice = Option
+					end
+				end
+				
+				ParsedArgs[RealArg.Name] = Choice or Default
 			end
 		end
 		


### PR DESCRIPTION
The `option` argument-type allows you to make your own enumerations.
Here's an example:
```lua
{
    Name = "alignment",
    Type = "option<top, middle, bottom>",
    Default = "middle"
}
```