### PR TITLE
commands: add aliases for speed

### DIFF
--- a/src/ServerScriptService/MainModule/Server/Dependencies/Commands.lua
+++ b/src/ServerScriptService/MainModule/Server/Dependencies/Commands.lua
@@ -14,7 +14,7 @@ return function()
 	Commands.Commands = {
 		{
 			Name = "speed";
-			Aliases = {"s"};
+			Aliases = {"s", "ws", "walkspeed"};
 			Level = Levels.Moderators;
 			PermissionNodes = {"MANAGE_CHARACTERS"};
 			Disabled = false; -- Optional


### PR DESCRIPTION
Walkspeed and ws

I think these aliases should be added as they are found common in other admin commands as aliases for speed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crywink/simpleadmin/19)
<!-- Reviewable:end -->
